### PR TITLE
[BREAKING CHANGE] feat(docker): mysql as user

### DIFF
--- a/lib/docker-compose.yml
+++ b/lib/docker-compose.yml
@@ -5,6 +5,11 @@ services:
   db:
     container_name: $DB_NAME
     image: $DB_IMAGE
+    build:
+      context: $DB_IMAGE_CONTEXT
+      args:
+        DOCKER_USER: $DOCKER_USER
+        DOCKER_USER_GROUP: $DOCKER_USER_GROUP
     environment:
       MYSQL_ROOT_PASSWORD: $DB_ROOT_PASSWORD
       MYSQL_DATABASE: $DB_DRUPAL_DB

--- a/lib/docker-images/drupal-mariadb/1.0.0/Dockerfile
+++ b/lib/docker-images/drupal-mariadb/1.0.0/Dockerfile
@@ -1,0 +1,12 @@
+FROM wodby/drupal-mariadb:1.0.0
+MAINTAINER OVH-UX <github@ovh.net>
+
+ARG DOCKER_USER=1000
+ARG DOCKER_USER_GROUP=1001
+
+# Override permissions with user/group of the host
+RUN echo http://dl.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
+RUN apk --no-cache add shadow && usermod -u $DOCKER_USER mysql && groupmod -g $DOCKER_USER_GROUP mysql
+RUN chown -R mysql:mysql /var/run/mysqld/
+
+ENTRYPOINT ["docker-entrypoint.sh", "mysqld", "--user=mysql", "--console"]

--- a/lib/docker-images/drupal-mariadb/1.0.0/Dockerfile
+++ b/lib/docker-images/drupal-mariadb/1.0.0/Dockerfile
@@ -4,9 +4,11 @@ MAINTAINER OVH-UX <github@ovh.net>
 ARG DOCKER_USER=1000
 ARG DOCKER_USER_GROUP=1001
 
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
+RUN apk update && apk --no-cache add shadow
+
 # Override permissions with user/group of the host
-RUN echo http://dl.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
-RUN apk --no-cache add shadow && usermod -u $DOCKER_USER mysql && groupmod -g $DOCKER_USER_GROUP mysql
+RUN usermod -u $DOCKER_USER mysql && groupmod -g $DOCKER_USER_GROUP mysql
 RUN chown -R mysql:mysql /var/run/mysqld/
 
 ENTRYPOINT ["docker-entrypoint.sh", "mysqld", "--user=mysql", "--console"]

--- a/lib/docker-images/drupal-mariadb/1.0.0/Dockerfile
+++ b/lib/docker-images/drupal-mariadb/1.0.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER OVH-UX <github@ovh.net>
 ARG DOCKER_USER=1000
 ARG DOCKER_USER_GROUP=1001
 
-RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community/ > /etc/apk/repositories
 RUN apk update && apk --no-cache add shadow
 
 # Override permissions with user/group of the host

--- a/lib/docker-images/drupal-nginx/8/1.13/Dockerfile
+++ b/lib/docker-images/drupal-nginx/8/1.13/Dockerfile
@@ -8,9 +8,11 @@ ARG DOCKER_USER_GROUP=1001
 # @see https://github.com/wodby/php/commit/d4c0b703310471b3555a360e343f6d7551162d37
 USER root
 
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
+RUN apk update && apk --no-cache add shadow
+
 # Override permissions with user/group of the host
-RUN echo http://dl.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
-RUN apk --no-cache add shadow && usermod -u $DOCKER_USER www-data && groupmod -g $DOCKER_USER_GROUP www-data
+RUN usermod -u $DOCKER_USER www-data && groupmod -g $DOCKER_USER_GROUP www-data
 ## Change files with old uid/gid
 RUN find / -group 82 -exec chgrp -h $DOCKER_USER_GROUP {} \; && find / -user 82 -exec chown -h $DOCKER_USER {} \;
 

--- a/lib/docker-images/drupal-node/8-alpine/Dockerfile
+++ b/lib/docker-images/drupal-node/8-alpine/Dockerfile
@@ -1,9 +1,8 @@
 FROM node:8-alpine
 MAINTAINER OVH-UX <github@ovh.net>
 
-RUN echo http://dl.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
-
-RUN apk add --update --no-cache build-base make gcc g++ python git tini
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
+RUN apk update && apk --no-cache add shadow build-base make gcc g++ python git tini
 
 RUN npm set progress=false && npm install -gq gulp-cli grunt-cli bower yo
 

--- a/lib/docker-images/drupal-php/7.0/Dockerfile
+++ b/lib/docker-images/drupal-php/7.0/Dockerfile
@@ -8,6 +8,9 @@ ARG DOCKER_USER_GROUP=1001
 # @see https://github.com/wodby/php/commit/d4c0b703310471b3555a360e343f6d7551162d37
 USER root
 
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
+RUN apk update && apk --no-cache add shadow
+
 # Deactivate IPv6
 ## @see https://github.com/wodby/base-php/blob/master/7.0/fpm/Dockerfile
 ## @see https://github.com/wodby/php/blob/master/7.0/templates/zz-www.conf.tpl
@@ -15,8 +18,7 @@ RUN sed -i "s/^listen = \[::\]:9000$/listen = 0.0.0.0:9000/" /usr/local/etc/php-
 RUN sed -i "s/^listen = \[::\]:9001$/listen = 0.0.0.0:9001/" /etc/gotpl/zz-www.conf.tpl
 
 # Override permissions with user/group of the host
-RUN echo http://dl.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
-RUN apk --no-cache add shadow && usermod -u $DOCKER_USER www-data && groupmod -g $DOCKER_USER_GROUP www-data
+RUN usermod -u $DOCKER_USER www-data && groupmod -g $DOCKER_USER_GROUP www-data
 ## Change files with old uid/gid
 RUN find / -group 82 -exec chgrp -h $DOCKER_USER_GROUP {} \; && find / -user 82 -exec chown -h $DOCKER_USER {} \;
 ## User www-data can su (for phproot)

--- a/lib/docker-images/drupal-php/7.1/Dockerfile
+++ b/lib/docker-images/drupal-php/7.1/Dockerfile
@@ -8,6 +8,9 @@ ARG DOCKER_USER_GROUP=1001
 # @see https://github.com/wodby/php/commit/d4c0b703310471b3555a360e343f6d7551162d37
 USER root
 
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
+RUN apk update && apk --no-cache add shadow
+
 # Deactivate IPv6
 ## @see https://github.com/wodby/base-php/blob/master/7.1/fpm/Dockerfile
 ## @see https://github.com/wodby/php/blob/master/7.1/templates/zz-www.conf.tpl
@@ -15,8 +18,7 @@ RUN sed -i "s/^listen = \[::\]:9000$/listen = 0.0.0.0:9000/" /usr/local/etc/php-
 RUN sed -i "s/^listen = \[::\]:9001$/listen = 0.0.0.0:9001/" /etc/gotpl/zz-www.conf.tpl
 
 # Override permissions with user/group of the host
-RUN echo http://dl.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories
-RUN apk --no-cache add shadow && usermod -u $DOCKER_USER www-data && groupmod -g $DOCKER_USER_GROUP www-data
+RUN usermod -u $DOCKER_USER www-data && groupmod -g $DOCKER_USER_GROUP www-data
 ## Change files with old uid/gid
 RUN find / -group 82 -exec chgrp -h $DOCKER_USER_GROUP {} \; && find / -user 82 -exec chown -h $DOCKER_USER {} \;
 ## User www-data can su (for phproot)

--- a/lib/environment
+++ b/lib/environment
@@ -41,7 +41,8 @@ export DB_SERVICE="${service}"
 # the container name:
 export DB_NAME="${PROJECT_NAME_PLAIN}_${service}"
 # the image to build the container from:
-export DB_IMAGE="wodby/drupal-mariadb"
+export DB_IMAGE="ovh/drupal-mariadb:1.0.0"
+export DB_IMAGE_CONTEXT="./docker-images/drupal-mariadb/1.0.0"
 # the db root password:
 export DB_ROOT_PASSWORD="drootpal"
 # credentials for the Drupal database:

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -34,6 +34,10 @@ docker build -t "${NODE_IMAGE}" "${NODE_CONTEXT}" --no-cache --pull
 echo "Installing dependencies..."
 composer install
 
+# Run drupal-scaffold
+echo "Running Drupal-scaffold..."
+composer run-script drupal-scaffold
+
 # Install and build custom themes
 echo "Building custom themes..."
 ./compile-themes.sh || warnings+=("Something goes wrong when compiling themes. Please try to compile them by yourself.")


### PR DESCRIPTION
BREAKING CHANGE
Run mysql docker as a user (to be able to use it with Vagrant).

If you're using previous version of Drucker, you need to:
- before pulling this new version: backup your database (`make sql-backup`)
- `make stop`
- pull this new version
- get your user id (`id -u`, for example 1000), and your group id (`id -g`, for example 1001)
- `sudo chown -R 1000:1001 (./drucker/)docker-runtime/mysql`
- `make start`
