### PR TITLE
fix(install) missing php open tag in generated settings.php

### DIFF
--- a/lib/install.sh
+++ b/lib/install.sh
@@ -114,6 +114,7 @@ if [ ! -e "$(projectdir)/www/web/sites/default/settings.local.php" ]; then
     echo "Creating settings.local.php..."
 
     # Activates it inside settings.php
+    echo "<?php" > "$(projectdir)/www/web/sites/default/settings.php"
     echo "if (file_exists(\$app_root . '/' . \$site_path . '/settings.local.php')) {" >> "$(projectdir)/www/web/sites/default/settings.php"
     echo "  include \$app_root . '/' . \$site_path . '/settings.local.php';" >> "$(projectdir)/www/web/sites/default/settings.php"
     echo "}" >> "$(projectdir)/www/web/sites/default/settings.php"


### PR DESCRIPTION
## Add PHP opening tag to generated settings.php 

### Description of the Change and benefits

This PR aims to fix or raise awareness on the following bug:

In a fresh installation, the generated settings.php was not prefixed by the php opening tag. Resulting in the code being output directly in the DOM, in the Drupal installation page, and probably elsewhere.

### Possible Drawbacks

If settings.php should have been generated or preexisting by conditions I could not replicate, then the file will be squashed instead of appended. 
