### PR TITLE
docs: refer to the new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The goals of this project is to have a Drupal development environment without in
 
 ## Documentation
 
-Full documentation is available [here](https://ovh-ux.github.io/drucker/).
+Full documentation is available [here](https://ovh.github.io/drucker/).
 
 
 ## Contributing

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -186,7 +186,7 @@ $ cd <name of the project>
 # Initialize an empty GIT project
 $ git init
 # Add Drucker in your project, as a Git submodule
-$ git submodule add https://github.com/ovh-ux/drucker.git drucker
+$ git submodule add https://github.com/ovh/drucker.git drucker
 # Launch a fresh install of Drupal
 $ cd drucker
 $ source load-env


### PR DESCRIPTION
repository has been transferred from `ovh-ux` organization to `ovh`

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
